### PR TITLE
Pypi Publishing Workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Upload MDonatello Package to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  pypi-publish:
+    name: Publish release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mdonatello
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Upgrade pip and install build module
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade build  # Ensures the latest version of build is installed
+      - name: Build package
+        run: |
+          python -m build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Changes made:

- `publish.yml` created, which publishes the package into pypi on release

You would need to create an account in pypi and add there the repository name and adjust here the `mdonatello` to your name of the package.

This workflow would currently only publish it for releases, adjust it if necessary.